### PR TITLE
Fixes #39: Voice selection not shown properly

### DIFF
--- a/src/screens/main_screen.py
+++ b/src/screens/main_screen.py
@@ -120,10 +120,12 @@ class MainScreen(MDScreen):
         try:
             # Retrieve the current voice for the selected engine
             self.selected_voice = api_factory.get_active_api().get_voice_name()
-            # Update the current voice display
-            self.ids.btn_select_voice.text = f"current voice:\n{self.selected_voice}"
         except:
             log.error(f"Could not retrieve set voice name of current TTS engine {current_engine}")
+            self.selected_voice = ""
+
+        # Update the current voice display
+        self.ids.btn_select_voice.text = f"current voice:\n{self.selected_voice}"
 
     def update_current_voice(self, instance, value):
         self.selected_voice = value if value is not None else ""
@@ -309,15 +311,16 @@ class MainScreen(MDScreen):
             self.selected_voice = api_factory.get_active_api().get_voice_name()
         except Exception:
             log.error("Getting current voice of selected API failed.")
-
-        # Update the current voice display
-        self.ids.btn_select_voice.text = f"current voice:\n{self.selected_voice}"
+            self.selected_voice = ""
 
         # Update the selected TTS engine in global settings or any relevant setting location
         App.get_running_app().global_settings.update_setting("TTS", "current_engine", engine_name)
 
         # Update the button text to display the selected engine
         self.update_current_engine_text()
+
+        # Update the current voice display
+        self.update_current_voice(None, self.selected_voice)
 
         # Dismiss the dropdown menu
         self.engine_dropdown_menu.dismiss()
@@ -352,12 +355,15 @@ class MainScreen(MDScreen):
         # process selected voice names
         log.info("%s: Selected voice: %s", self.__class__.__name__, voice_name)
         api = api_factory.get_active_api()
-        current_engine = self.get_current_tts_engine()
         api.set_voice_name(voice_name)
 
         popup_window = CustomPopup(content_text=f"You selected the voice: \n{voice_name}",
                                    size_hint=(None, None), size=(400, 400))
         popup_window.open()
+
+        # Update the current voice display
+        self.update_current_voice(None, voice_name)
+
         self.voice_dropdown_menu.dismiss()
 
     def on_play(self):


### PR DESCRIPTION
Fixes #39: Voice selection not shown properly:

* after selecting a new voice, self.update_current_voice must be called
* When changing the tts engine and the retrieval of the voice fails, the current voice is set to an empty string, otherwise the previous voice would still be shown.